### PR TITLE
`case` do not support fallthrough

### DIFF
--- a/xdg-open
+++ b/xdg-open
@@ -112,7 +112,7 @@ if [[ "$arg" =~ ^([a-zA-Z-]+): ]]; then
 		irc)
 			mime=x-scheme-handler/irc
 			;;
-		mailto | tg )
+		mailto|tg)
 			mime=x-scheme-handler/mailto
 			;;
 	esac

--- a/xdg-open
+++ b/xdg-open
@@ -112,9 +112,7 @@ if [[ "$arg" =~ ^([a-zA-Z-]+): ]]; then
 		irc)
 			mime=x-scheme-handler/irc
 			;;
-		mailto)
-			mime=x-scheme-handler/mailto
-		tg)
+		mailto | tg )
 			mime=x-scheme-handler/mailto
 			;;
 	esac


### PR DESCRIPTION
We may either use `;&` or `;;&` which was introduced in Bash 4.0 if we want to support case fallthrough.  However, in this case, it isn't needed since we want to handle `mailto` and `tg` in the same way so we may as well consolidate them into a single case.