### PR TITLE
fix: replace invalid `stest` utility with `compgen`

### DIFF
--- a/xdg-open
+++ b/xdg-open
@@ -168,7 +168,7 @@ done
 
 # ask
 if exists $MENU; then
-	app=($(IFS=:; stest -flx $PATH | sort -u | $MENU -p "how to open $(basename $arg)" $MENUARGS))
+	app=($(compgen -c | sort -u | $MENU -p "how to open $(basename $arg)" $MENUARGS))
 	[[ "${app[*]}" ]] && fork_run "${app[@]}" "$arg"
 elif exists notify-send; then
 	notify-send "Could not find opener, exiting..."


### PR DESCRIPTION
Fixes an issue on line 171 that calls a nonexistent bash builtin `stest`. Replacing `stest` with `test` did not fix the issue, so I used a separated bash utility, `compgen -c`, to list executables on the path.

To reproduce the issue, call `xdg-open` on any file with no registered handler, such as a `.json`. 